### PR TITLE
Ingest and display NIBRS data

### DIFF
--- a/app/datatables/incident_datatable.rb
+++ b/app/datatables/incident_datatable.rb
@@ -12,6 +12,10 @@ class IncidentDatatable < ApplicationDatatable
       nature_of_incident: {source: "Incident.nature_of_incident", searchable: false},
       offenses: {source: "Incident.offenses", searchable: false, orderable: false},
       officer_journal_name: {source: "Incident.officer_journal_name", searchable: false},
+      incident_clearance: {source: "Incident.incident_clearance", searchable: false},
+      number_of_arrestees: {source: "Incident.number_of_arrestees", searchable: false},
+      number_of_victims: {source: "Incident.number_of_victims", searchable: false},
+      number_of_offenders: {source: "Incident.number_of_offenders", searchable: false},
       bag_of_text: {source: "Incident.bag_of_text", searchable: true, orderable: false}
     }
   end
@@ -29,7 +33,11 @@ class IncidentDatatable < ApplicationDatatable
       street: record.street,
       nature_of_incident: record.nature_of_incident,
       officer_journal_name: record.officer_journal_name,
-      offenses: record.offenses.map(&:description)
+      offenses: record.offenses.map(&:description),
+      incident_clearance: record.incident_clearance,
+      number_of_arrestees: record.number_of_arrestees,
+      number_of_victims: record.number_of_victims,
+      number_of_offenders: record.number_of_offenders
     }
   end
 

--- a/app/javascript/shared/tables/incidents.js
+++ b/app/javascript/shared/tables/incidents.js
@@ -14,7 +14,11 @@ initDataTable("table.incidents-table", function($table, options) {
       {data: "shooting", render: shooting_renderer},
       {data: "location_of_occurrence", render: location_renderer, orderable: false},
       {data: "offenses", render: offenses_renderer, orderable: false},
-      {data: "officer_journal_name", render: text_renderer}
+      {data: "officer_journal_name", render: text_renderer},
+      {data: "incident_clearance", render: text_renderer},
+      {data: "number_of_victims", render: int_renderer},
+      {data: "number_of_offenders", render: int_renderer},
+      {data: "number_of_arrestees", render: int_renderer},
     ],
     order: [[2, 'desc']]
   });

--- a/app/lib/importer/crime_incident_reports.rb
+++ b/app/lib/importer/crime_incident_reports.rb
@@ -5,6 +5,7 @@ class Importer::CrimeIncidentReports < Importer::Importer
   def self.import_all
     import_legacy
     import_non_legacy
+    import_nibrs
   end
 
   def self.import_legacy
@@ -14,6 +15,11 @@ class Importer::CrimeIncidentReports < Importer::Importer
 
   def self.import_non_legacy
     parser = Parser::CrimeIncidentReports.new("data/crime_incident_reports.csv.gz")
+    new(parser).import
+  end
+
+  def self.import_nibrs
+    parser = Parser::NibrsIncidentReports.new("data/boston_nibrs_foia.csv.gz")
     new(parser).import
   end
 
@@ -27,16 +33,22 @@ class Importer::CrimeIncidentReports < Importer::Importer
 
   private
   def import_slice(slice)
+    is_nibrs = @parser.attribution.category.include?("nibrs")
+
     numbers = slice.pluck(:incident_number)
       .map { |n| parse_incident_number(n) }.compact
     by_number = incidents_by_number(numbers)
 
     slice.each do |record|
-      attr = map_record(record)
+      attr = is_nibrs ? map_nibrs_record(record) : map_record(record)
       if attr[:incident_number]
         incident = by_number[attr[:incident_number]]
         incident.attributes = attr
-        incident.add_offense(map_offense(record))
+        if is_nibrs
+          incident.add_nibrs_offense(map_nibrs_offense(record))
+        else
+          incident.add_offense(map_offense(record))
+        end
         incident.add_attribution(attribution)
       end
     end
@@ -78,5 +90,33 @@ class Importer::CrimeIncidentReports < Importer::Importer
       return({ latitude: nil, longitude: nil })
     end
     h
+  end
+
+  private
+  def map_nibrs_record(record)
+    {
+      incident_number: parse_incident_number(record[:incident_number]),
+      location_type: parse_string(record[:location_type]),
+      incident_clearance: parse_string(record[:incident_clearance]),
+      exceptional_clearance_date: parse_string(record[:exceptional_clearance_date]),
+      number_of_victims: parse_int(record[:number_of_victims_in_incident]),
+      number_of_offenders: parse_int(record[:number_of_offenders_in_incident]),
+      number_of_arrestees: parse_int(record[:number_of_arrestees_in_incident])
+    }
+  end
+
+  private
+  def map_nibrs_offense(record)
+    mapped_offense = NibrsOffense.new(
+        ucr_code: parse_string(record[:offense_code]),
+        description: parse_string(record[:offense_type]),
+        attempted_or_completed: parse_string(record[:attempted_or_completed]),
+        number_of_crimes: parse_int(record[:number_of_crimes]),
+        number_of_victims: parse_int(record[:number_of_victims]),
+        number_of_stolen_vehicles: parse_int(record[:number_of_stolen_vehicles]),
+        number_of_recovered_vehicles: parse_int(record[:number_of_recovered_vehicles]),
+        method_of_entry: parse_string(record[:method_of_entry]),
+        number_of_premises_entered: parse_int(record[:number_of_premises_entered])
+    )
   end
 end

--- a/app/lib/parser/nibrs_incident_reports.rb
+++ b/app/lib/parser/nibrs_incident_reports.rb
@@ -1,0 +1,5 @@
+class Parser::NibrsIncidentReports < Parser::Csv
+    def category
+        "nibrs_incident_reports"
+    end
+end

--- a/app/models/attribution.rb
+++ b/app/models/attribution.rb
@@ -6,6 +6,7 @@ class Attribution
   FRIENDLY_MAPPING = {
     "district_journal" => "Public Journal",
     "crime_incident_reports" => "Crime Incident Reports",
+    "nibrs_incident_reports" => "NIBRS Incident Reports",
     "field_contact" => "FIO Records FieldContact Table",
     "field_contact_name" => "FIO Records FieldContact_Name Table",
     "employee_earnings" => "Employee Earnings Report",

--- a/app/models/concerns/offenses.rb
+++ b/app/models/concerns/offenses.rb
@@ -2,21 +2,30 @@ module Offenses
   extend ActiveSupport::Concern
 
   class Coder
-    def self.dump(obj)
+    def initialize(offense_class)
+      @offense_class = offense_class
+    end
+
+    def dump(obj)
       ActiveSupport::JSON.encode(obj.map(&:attributes))
     end
 
-    def self.load(json)
+    def load(json)
       return [] if json.blank?
-      JSON.parse(json).map { |j| Offense.new(j) }
+      JSON.parse(json).map { |j| @offense_class.new(j) }
     end
   end
 
   included do
-    serialize :offenses, Coder
+    serialize :offenses, Coder.new(Offense)
+    serialize :nibrs_offenses, Coder.new(NibrsOffense)
   end
 
   def add_offense(offense)
     offenses << offense if !offenses.include?(offense)
+  end
+
+  def add_nibrs_offense(nibrs_offense)
+    nibrs_offenses << nibrs_offense if !nibrs_offenses.include?(nibrs_offense)
   end
 end

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -34,7 +34,7 @@ class Incident < ApplicationRecord
   counter_culture :officer
 
   def bag_of_text_content
-    [incident_number, district, district_name, location_of_occurrence, street, nature_of_incident, officer_journal_name, offenses.map(&:description).join(" "), ApplicationController.helpers.format_date_time(occurred_on_date)]
+    [incident_number, district, district_name, location_of_occurrence, street, nature_of_incident, officer_journal_name, incident_clearance, offenses.map(&:description).join(" "), nibrs_offenses.map(&:description).join(" "), ApplicationController.helpers.format_date_time(occurred_on_date)]
   end
 
   def arrests=(arr)

--- a/app/models/nibrs_offense.rb
+++ b/app/models/nibrs_offense.rb
@@ -1,0 +1,38 @@
+class NibrsOffense
+  include ActiveModel::Model
+
+  attr_accessor(
+    :ucr_code,
+    :description,
+    :attempted_or_completed,
+    :number_of_crimes,
+    :number_of_victims,
+    :number_of_stolen_vehicles,
+    :number_of_recovered_vehicles,
+    :method_of_entry,
+    :number_of_premises_entered
+  )
+
+  def ==(o)
+    o.class == self.class && o.attributes == self.attributes
+  end
+  alias_method :eql?, :==
+
+  def hash
+    attributes.hash
+  end
+
+  def attributes
+    {
+      "ucr_code" => ucr_code,
+      "description" => description,
+      "attempted_or_completed" => attempted_or_completed,
+      "number_of_crimes" => number_of_crimes,
+      "number_of_victims" => number_of_victims,
+      "number_of_stolen_vehicles" => number_of_stolen_vehicles,
+      "number_of_recovered_vehicles" => number_of_recovered_vehicles,
+      "method_of_entry" => method_of_entry,
+      "number_of_premises_entered" => number_of_premises_entered
+    }
+  end
+end

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -25,12 +25,24 @@
             <dd class="col-lg-8"><%= format_text(@incident.street) %></dd>
             <dt class="col-lg-4">Location</dt>
             <dd class="col-lg-8"><%= format_array(@incident.location_of_occurrence) %></dd>
+            <dt class="col-lg-4">Location Type</dt>
+            <dd class="col-lg-8"><%= format_text(@incident.location_type) %></dd>
             <dt class="col-lg-4">Nature of Incident</dt>
             <dd class="col-lg-8"><%= format_array(@incident.nature_of_incident) %></dd>
             <dt class="col-lg-4">Lat/Long</dt>
             <dd class="col-lg-8"><%= format_lat_long(@incident.latitude, @incident.longitude) %></dd>
             <dt class="col-lg-4">Officer</dt>
             <dd class="col-lg-8"><%= format_incident_officer(@incident) %></dd>
+            <dt class="col-lg-4">Incident Clearance</dt>
+            <dd class="col-lg-8"><%= format_text(@incident.incident_clearance) %></dd>
+            <dt class="col-lg-4">Exceptional Clearance Date</dt>
+            <dd class="col-lg-8"><%= format_text(@incident.exceptional_clearance_date) %></dd>
+            <dt class="col-lg-4">Number of Victims</dt>
+            <dd class="col-lg-8"><%= format_text(@incident.number_of_victims) %></dd>
+            <dt class="col-lg-4">Number of Offenders</dt>
+            <dd class="col-lg-8"><%= format_text(@incident.number_of_offenders) %></dd>
+            <dt class="col-lg-4">Number of Arrests</dt>
+            <dd class="col-lg-8"><%= format_text(@incident.number_of_arrestees) %></dd>
             <% if !@incident.cases.empty? %>
               <dt class="col-lg-4">Case</dt>
               <dd class="col-lg-8"><%= format_cases(@incident.cases) %></dd>
@@ -42,7 +54,7 @@
           </dl>
         </div>
         <div class="col-md-6">
-            <div style="height:350px" id="incident-map" data-controller="map" data-map-latitude="<%= @incident.latitude %>" data-map-longitude="<%= @incident.longitude %>">
+            <div style="height:450px" id="incident-map" data-controller="map" data-map-latitude="<%= @incident.latitude %>" data-map-longitude="<%= @incident.longitude %>">
               <p class="text-center text-muted font-italic">No latitude/longitude data for this incident</p>
             </div>
             <p class="text-muted font-italic">Map location is sometimes inaccurate; trust the Street &amp; Location fields if there is a discrepancy.</p>
@@ -52,6 +64,7 @@
       <div class="row">
         <div class="col-md">
           <h2>Offenses</h2>
+          <p class="text-muted">As recorded in the BPD's internal record management system.</p>
           <table class="table table-bordered">
             <thead>
               <tr>
@@ -75,6 +88,34 @@
           </table>
         </div>
 
+        <div class="col-md">
+          <h2>NIBRS Offenses</h2>
+          <p class="text-muted">As recorded in the National Incident-Based Reporting System.</p>
+          <table class="table table-bordered">
+            <thead>
+              <tr>
+                <th>UCR Code</th>
+                <th>Description</th>
+                <th>Completion</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% if @incident.nibrs_offenses.empty? %>
+                <td colspan="3" class="empty-table">NIBRS Offense records not found for this incident.</td>
+              <% end %>
+              <% @incident.nibrs_offenses.each do |offense| %>
+                <tr>
+                  <td><%= format_text(offense.ucr_code) %></td>
+                  <td><%= format_text(offense.description) %></td>
+                  <td><%= format_text(offense.attempted_or_completed) %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="row">
         <div class="col-md">
           <h2>Arrests</h2>
           <table class="table table-bordered">

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -459,6 +459,87 @@
         </tbody>
       </table>
 
+      <h3 id="nibrs_incident_reports">NIBRS Incident Reports</h3>
+      <p>
+        <a href="https://www.muckrock.com/foi/massachusetts-1/boston-police-nibrs-files-98203/">https://www.muckrock.com/foi/massachusetts-1/boston-police-nibrs-files-98203/</a>
+      </p>
+      <p>
+        Since September 2019, the Boston Police Department has submitted incident data to the FBI's 
+        <a href="https://en.wikipedia.org/wiki/National_Incident-Based_Reporting_System">National Incident-Based Reporting System (NIBRS)</a>. 
+        Obtained through a public records request, this dataset provides additional incident information not tracked in the BPD's 
+        <a href="#crime_incident_reports">Crime Incident Reports</a>.
+        <a>
+      </p>
+      <p>The City of Boston has made only the data for September 2019 through December 2019 available. Data for 2020 will not be available until 2021.</p>
+      <p>Like the <a href="#crime_incident_reports">Crime Incident Reports</a> dataset, each row in the original dataset corresponds to a single offense. An incident may include multiple offenses.</p>
+      <p>Note: the original dataset includes additional columns that Woke Windows does not yet ingest.</p>
+      <table class="table help__definitions">
+        <thead>
+          <tr>
+            <th>Field Name</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Incident Number</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Offense Code</td>
+            <td>the Uniform Crime Reporting (UCR) code for the offense</td>
+          </tr>
+          <tr>
+            <td>Offense Type</td>
+            <td>a description of the alleged offense</td>
+          </tr>
+          <tr>
+            <td>Attempted or Completed</td>
+            <td>whether the offense was "attempted" or "completed"</td>
+          </tr>
+          <tr>
+            <td>Number of Crimes</td>
+            <td>(offense-level property)</td>
+          </tr>
+          <tr>
+            <td>Number of Victims</td>
+            <td>(offense-level property)</td>
+          </tr>
+          <tr>
+            <td>Number of Stolen Vehicles</td>
+            <td>(offense-level property)</td>
+          </tr>
+          <tr>
+            <td>Number of Recovered Vehicles</td>
+            <td>(offense-level property)</td>
+          </tr>
+          <tr>
+            <td>Method of Entry</td>
+            <td>in the case of a burglary offense, whether entry was "forced" or "not forced"</td>
+          </tr>
+          <tr>
+            <td>Location Type</td>
+            <td>the type of place where the incident happened</td>
+          </tr>
+          <tr>
+            <td>Incident Clearance</td>
+            <td>the incident's resolution (e.g., if a suspected offender was arrested)</td>
+          </tr>
+          <tr>
+            <td>Number of Victims in Incident</td>
+            <td>(incident-level property)</td>
+          </tr>
+          <tr>
+            <td>Number of Offenders in Incident</td>
+            <td>(incident-level property)</td>
+          </tr>
+          <tr>
+            <td>Number of Arrestees in Incident</td>
+            <td>(incident-level property)</td>
+          </tr>
+        </tbody>
+      </table>
+
       <h3 id="district_journal">Public Journal</h3>
       <p>On an almost daily basis, The Boston Police Department posts on <a href="https://bpdnews.com/">bpdnews.com</a> a public journal of the incident reports filed by officers.</p>
       <p>This data is similar to and overlaps with that provided by the <a href="#crime_incident_reports">Crime Incident Reports</a>. However, the journals provide some additional information: the officer who responded, and any arrests that were made.</p>

--- a/app/views/shared/tables/_incidents.html.erb
+++ b/app/views/shared/tables/_incidents.html.erb
@@ -12,5 +12,9 @@
   <th scope="col">Location</th>
   <th scope="col">Offenses</th>
   <th scope="col">Officer</th>
+  <th scope="col">Clearance</th>
+  <th scope="col"># of Victims</th>
+  <th scope="col"># of Offenders</th>
+  <th scope="col"># of Arrests</th>
 </tr>
 <% end %>

--- a/db/migrate/20200813231723_add_nibrs_columns_to_incidents.rb
+++ b/db/migrate/20200813231723_add_nibrs_columns_to_incidents.rb
@@ -1,0 +1,11 @@
+class AddNibrsColumnsToIncidents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :incidents, :nibrs_offenses, :jsonb, default: []
+    add_column :incidents, :location_type, :string
+    add_column :incidents, :incident_clearance, :string
+    add_column :incidents, :exceptional_clearance_date, :string
+    add_column :incidents, :number_of_victims, :integer
+    add_column :incidents, :number_of_offenders, :integer
+    add_column :incidents, :number_of_arrestees, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_13_160733) do
+ActiveRecord::Schema.define(version: 2020_08_13_231723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -305,6 +305,13 @@ ActiveRecord::Schema.define(version: 2020_08_13_160733) do
     t.float "geocode_longitude"
     t.float "reported_latitude"
     t.float "reported_longitude"
+    t.jsonb "nibrs_offenses", default: []
+    t.string "location_type"
+    t.string "incident_clearance"
+    t.string "exceptional_clearance_date"
+    t.integer "number_of_victims"
+    t.integer "number_of_offenders"
+    t.integer "number_of_arrestees"
     t.index ["bag_of_text"], name: "incidents_bag_of_text_gin", opclass: :gin_trgm_ops, using: :gin
     t.index ["incident_number"], name: "index_incidents_on_incident_number", unique: true
     t.index ["occurred_on_date"], name: "index_incidents_on_occurred_on_date"

--- a/spec/fixtures/files/sample_boston_nibrs_foia.csv
+++ b/spec/fixtures/files/sample_boston_nibrs_foia.csv
@@ -1,0 +1,100 @@
+ORI,Incident Number,Incident Date,Offense Code,Offense Type,Attempted or Completed,Number of Crimes,Number of Victims,Number of Stolen Vehicles,Number of Recovered Vehicles,Location Type,Method of Entry,Number of Premises Entered,Incident Month,Day of Week,Hour of Day,County,Agency Name,Incident Clearance,Exceptional Clearance Date,Number of Offenses in Incident,Number of Victims in Incident,Number of Offenders in Incident,Number of Arrestees in Incident
+MA0130100,192092484,2019-11-15,220,Burglary/Breaking & Entering,Completed,1,3,0,0,Residence/Home,Forced Entry,0,November,Friday,8:00am-8:59am,Suffolk County,Boston,Not Cleared,,1,3,1,0
+MA0130100,192093419,2019-10-30,23F,Theft From Motor Vehicle,Completed,1,1,0,0,Residence/Home,Missing,0,October,Wednesday,12:00am-12:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192081426,2019-10-04,26C,Impersonation,Completed,1,1,0,0,Residence/Home,Missing,0,October,Friday,3:00pm-3:59pm,Suffolk County,Boston,Not Cleared,,2,1,2,0
+MA0130100,192091264,2019-11-10,23D,Theft From Building,Completed,1,1,0,0,Department/Discount Store,Missing,0,November,Sunday,8:00pm-8:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192083612,2019-10-15,120,Robbery,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,October,Tuesday,9:00pm-9:59pm,Suffolk County,Boston,Not Cleared,,1,1,2,0
+MA0130100,192103097,2019-12-18,23H,All Other Larceny,Completed,1,1,0,0,Residence/Home,Missing,0,December,Wednesday,6:00pm-6:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192084911,2019-10-20,23H,All Other Larceny,Completed,1,1,0,0,Commercial/Office Building,Missing,0,October,Sunday,2:00am-2:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,202014197,2019-11-03,13C,Intimidation,Completed,1,1,0,0,Residence/Home,Missing,0,November,Sunday,12:00n-12:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192082137,2019-10-08,26C,Impersonation,Completed,1,1,0,0,Residence/Home,Missing,0,October,Tuesday,3:00pm-3:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192081595,2019-10-08,520,Weapon Law Violations,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,October,Tuesday,8:00pm-8:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192104577,2019-12-27,23H,All Other Larceny,Completed,1,1,0,0,Residence/Home,Missing,0,December,Friday,3:00am-3:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192101595,2019-12-17,13B,Simple Assault,Completed,1,1,0,0,Residence/Home,Missing,0,December,Tuesday,9:00pm-9:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192096352,2019-11-28,13A,Aggravated Assault,Completed,1,1,0,0,Residence/Home,Missing,0,November,Thursday,9:00pm-9:59pm,Suffolk County,Boston,Cleared by Arrest,,1,1,1,1
+MA0130100,192097342,2019-12-03,13B,Simple Assault,Completed,1,1,0,0,Residence/Home,Missing,0,December,Tuesday,2:00am-2:59am,Suffolk County,Boston,Cleared by Arrest,,1,1,1,1
+MA0130100,192082823,2019-10-13,13B,Simple Assault,Completed,1,1,0,0,Bar/Nightclub,Missing,0,October,Sunday,2:00am-2:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192093997,2019-11-20,13B,Simple Assault,Completed,1,1,0,0,Residence/Home,Missing,0,November,Wednesday,1:00pm-1:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192093388,2019-11-18,35B,Drug Equipment Violations,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,November,Monday,1:00pm-1:59pm,Suffolk County,Boston,Not Cleared,,2,1,3,0
+MA0130100,192092422,2019-11-14,13B,Simple Assault,Completed,2,2,0,0,Restaurant,Missing,0,November,Thursday,11:00pm-11:59pm,Suffolk County,Boston,Not Cleared,,1,2,1,0
+MA0130100,192100185,2019-12-13,13A,Aggravated Assault,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,December,Friday,12:00am-12:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192093083,2019-11-17,120,Robbery,Completed,1,1,0,0,Residence/Home,Missing,0,November,Sunday,9:00am-9:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192094447,2019-11-21,13B,Simple Assault,Completed,1,1,0,0,Residence/Home,Missing,0,November,Thursday,8:00pm-8:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192092587,2019-11-15,13B,Simple Assault,Completed,1,1,0,0,Residence/Home,Missing,0,November,Friday,1:00pm-1:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,202001776,2019-12-12,13B,Simple Assault,Completed,1,1,0,0,School – Elementary/Secondary,Missing,0,December,Thursday,9:00am-9:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192079712,2019-10-02,26B,Credit Card/Automatic Teller Fraud,Completed,1,1,0,0,Restaurant,Missing,0,October,Wednesday,9:00am-9:59am,Suffolk County,Boston,Not Cleared,,2,1,2,0
+MA0130100,192088528,2019-11-01,13A,Aggravated Assault,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,November,Friday,11:00am-11:59am,Suffolk County,Boston,Cleared by Arrest,,1,1,1,1
+MA0130100,192099213,2019-12-07,23F,Theft From Motor Vehicle,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,December,Saturday,8:00pm-8:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192099736,2019-12-11,13B,Simple Assault,Completed,1,1,0,0,Convenience Store,Missing,0,December,Wednesday,2:00pm-2:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192099460,2019-12-10,26B,Credit Card/Automatic Teller Fraud,Completed,1,1,0,0,Restaurant,Missing,0,December,Tuesday,3:00pm-3:59pm,Suffolk County,Boston,Not Cleared,,2,1,2,0
+MA0130100,192095709,2019-11-26,26B,Credit Card/Automatic Teller Fraud,Completed,1,1,0,0,Residence/Home,Missing,0,November,Tuesday,12:00am-12:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192101010,2019-12-15,13B,Simple Assault,Completed,3,3,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,December,Sunday,10:00pm-10:59pm,Suffolk County,Boston,Cleared by Arrest,,1,3,1,1
+MA0130100,192102028,2019-11-15,23H,All Other Larceny,Completed,1,1,0,0,Residence/Home,Missing,0,November,Friday,8:00am-8:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192099762,2019-12-11,23H,All Other Larceny,Completed,1,2,0,0,Other/Unknown,Missing,0,December,Wednesday,4:00pm-4:59pm,Suffolk County,Boston,Not Cleared,,2,2,1,0
+MA0130100,192080429,2019-10-04,23H,All Other Larceny,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,October,Friday,6:00pm-6:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192091052,2019-11-10,13A,Aggravated Assault,Completed,1,1,0,0,Bar/Nightclub,Missing,0,November,Sunday,1:00am-1:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192094634,2019-11-20,23D,Theft From Building,Completed,1,1,0,0,Residence/Home,Missing,0,November,Wednesday,2:00pm-2:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192098622,2019-12-07,13C,Intimidation,Completed,1,1,0,0,Residence/Home,Missing,0,December,Saturday,4:00pm-4:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192086286,2019-10-24,290,Destruction/Damage/Vandalism of Property,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,October,Thursday,4:00pm-4:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192083066,2019-10-14,120,Robbery,Attempted,1,1,0,0,Other/Unknown,Missing,0,October,Monday,1:00am-1:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192090594,2019-11-04,23F,Theft From Motor Vehicle,Completed,1,1,0,0,Parking/Drop Lot/Garage,Missing,0,November,Monday,8:00pm-8:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192092055,2019-11-13,23D,Theft From Building,Completed,1,1,0,0,Other/Unknown,Missing,0,November,Wednesday,12:00am-12:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192089078,2019-11-02,13B,Simple Assault,Completed,1,1,0,0,Residence/Home,Missing,0,November,Saturday,3:00pm-3:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192102502,2019-12-21,13B,Simple Assault,Completed,1,1,0,0,Residence/Home,Missing,0,December,Saturday,1:00am-1:59am,Suffolk County,Boston,Cleared by Arrest,,1,1,1,1
+MA0130100,192100332,2019-12-13,13A,Aggravated Assault,Completed,1,1,0,0,School – Elementary/Secondary,Missing,0,December,Friday,10:00am-10:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192092097,2019-11-13,11D,Fondling,Completed,1,1,0,0,Convenience Store,Missing,0,November,Wednesday,8:00pm-8:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192095011,2019-11-23,13A,Aggravated Assault,Completed,1,1,0,0,Community Center,Missing,0,November,Saturday,10:00pm-10:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192098901,2019-12-08,26A,False Pretenses/Swindle/Confidence Game,Completed,1,1,0,0,Auto Dealership New/Used,Missing,0,December,Sunday,12:00am-12:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192100721,2019-12-14,13B,Simple Assault,Completed,1,1,0,0,Residence/Home,Missing,0,December,Saturday,5:00pm-5:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192097579,2019-12-04,23C,Shoplifting,Completed,1,1,0,0,Convenience Store,Missing,0,December,Wednesday,2:00am-2:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192092011,2019-11-13,13B,Simple Assault,Completed,1,1,0,0,Department/Discount Store,Missing,0,November,Wednesday,3:00pm-3:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192088726,2019-11-01,13B,Simple Assault,Completed,1,1,0,0,Other/Unknown,Missing,0,November,Friday,8:00pm-8:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192080996,2019-10-07,13A,Aggravated Assault,Completed,1,1,0,0,Residence/Home,Missing,0,October,Monday,5:00am-5:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192091542,2019-11-11,13B,Simple Assault,Completed,1,1,0,0,Restaurant,Missing,0,November,Monday,7:00pm-7:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192095825,2019-11-26,13A,Aggravated Assault,Completed,1,1,0,0,Residence/Home,Missing,0,November,Tuesday,6:00pm-6:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192101944,2019-12-19,23C,Shoplifting,Completed,1,1,0,0,Drug Store/Doctor’s Office/Hospital,Missing,0,December,Thursday,7:00am-7:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192086704,2019-10-26,13B,Simple Assault,Completed,2,2,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,October,Saturday,2:00am-2:59am,Suffolk County,Boston,Not Cleared,,1,2,1,0
+MA0130100,192088569,2019-11-01,11A,Rape,Completed,1,1,0,0,Residence/Home,Missing,0,November,Friday,12:00n-12:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192091525,2019-11-10,26B,Credit Card/Automatic Teller Fraud,Completed,1,1,0,0,Residence/Home,Missing,0,November,Sunday,3:00am-3:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192098279,2019-12-06,13B,Simple Assault,Completed,3,3,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,December,Friday,11:00am-11:59am,Suffolk County,Boston,Not Cleared,,1,3,1,0
+MA0130100,192098340,2019-12-06,23D,Theft From Building,Completed,1,1,0,0,Residence/Home,Missing,0,December,Friday,1:00pm-1:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192091035,2019-11-10,280,Stolen Property Offenses,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,November,Sunday,12:00am-12:59am,Suffolk County,Boston,Cleared by Arrest,,1,1,1,1
+MA0130100,192082749,2019-10-12,23C,Shoplifting,Completed,1,1,0,0,Commercial/Office Building,Missing,0,October,Saturday,7:00pm-7:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192087399,2019-10-26,23F,Theft From Motor Vehicle,Completed,1,2,0,0,Residence/Home,Missing,0,October,Saturday,10:00pm-10:59pm,Suffolk County,Boston,Not Cleared,,1,2,1,0
+MA0130100,192103375,2019-12-24,23A,Pocket-picking,Completed,1,1,0,0,Grocery/Supermarket,Missing,0,December,Tuesday,12:00n-12:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192091315,2019-11-11,220,Burglary/Breaking & Entering,Completed,1,2,0,0,Hotel/Motel/Etc.,Non-Forced Entry,1,November,Monday,3:00am-3:59am,Suffolk County,Boston,Not Cleared,,2,2,1,0
+MA0130100,192104713,2019-12-30,13C,Intimidation,Completed,1,1,0,0,Shelter – Mission/Homeless,Missing,0,December,Monday,10:00am-10:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192092873,2019-10-01,23H,All Other Larceny,Completed,1,1,0,0,Residence/Home,Missing,0,October,Tuesday,12:00am-12:59am,Suffolk County,Boston,Not Cleared,,1,1,2,0
+MA0130100,192104930,2019-10-16,13C,Intimidation,Completed,1,1,0,0,Residence/Home,Missing,0,October,Wednesday,12:00am-12:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192093822,2019-11-19,13B,Simple Assault,Completed,1,1,0,0,Residence/Home,Missing,0,November,Tuesday,8:00pm-8:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192093564,2019-11-16,13B,Simple Assault,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,November,Saturday,12:00am-12:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192084528,2019-10-18,13B,Simple Assault,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,October,Friday,4:00pm-4:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192094776,2019-11-23,13A,Aggravated Assault,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,November,Saturday,1:00am-1:59am,Suffolk County,Boston,Cleared by Arrest,,1,1,1,1
+MA0130100,190556958,2019-10-15,26B,Credit Card/Automatic Teller Fraud,Completed,1,1,0,0,Residence/Home,Missing,0,October,Tuesday,8:00pm-8:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192082413,2019-10-11,23H,All Other Larceny,Completed,1,1,0,0,Residence/Home,Missing,0,October,Friday,3:00am-3:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,202002370,2019-12-31,26E,Wire Fraud,Completed,1,1,0,0,Residence/Home,Missing,0,December,Tuesday,12:00am-12:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192092027,2019-11-13,13B,Simple Assault,Completed,1,1,0,0,Parking/Drop Lot/Garage,Missing,0,November,Wednesday,3:00pm-3:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192082891,2019-10-12,23F,Theft From Motor Vehicle,Completed,1,1,0,0,Other/Unknown,Missing,0,October,Saturday,5:00pm-5:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192091666,2019-11-12,13B,Simple Assault,Completed,1,1,0,0,Grocery/Supermarket,Missing,0,November,Tuesday,11:00am-11:59am,Suffolk County,Boston,Cleared by Arrest,,1,1,1,1
+MA0130100,192085409,2019-10-21,13A,Aggravated Assault,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,October,Monday,9:00pm-9:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192081600,2019-10-08,23C,Shoplifting,Completed,1,1,0,0,Liquor Store,Missing,0,October,Tuesday,8:00pm-8:59pm,Suffolk County,Boston,Not Cleared,,1,1,2,0
+MA0130100,192093690,2019-11-19,26A,False Pretenses/Swindle/Confidence Game,Attempted,1,1,0,0,Shopping Mall,Missing,0,November,Tuesday,2:00pm-2:59pm,Suffolk County,Boston,Cleared by Arrest,,2,2,1,1
+MA0130100,192084506,2019-10-18,35A,Drug/Narcotic Violations,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,October,Friday,2:00pm-2:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192086854,2019-10-26,23D,Theft From Building,Completed,1,1,0,0,Other/Unknown,Missing,0,October,Saturday,2:00pm-2:59pm,Suffolk County,Boston,Not Cleared,,2,1,1,0
+MA0130100,192096515,2019-11-29,13B,Simple Assault,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,November,Friday,4:00am-4:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192099191,2019-12-09,13A,Aggravated Assault,Completed,1,1,0,0,Convenience Store,Missing,0,December,Monday,6:00pm-6:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192100227,2019-12-12,13C,Intimidation,Completed,1,1,0,0,Residence/Home,Missing,0,December,Thursday,4:00pm-4:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192095706,2019-11-16,13C,Intimidation,Completed,2,2,0,0,Rental Storage Facility,Missing,0,November,Saturday,2:00pm-2:59pm,Suffolk County,Boston,Not Cleared,,1,2,1,0
+MA0130100,192092919,2019-11-16,13B,Simple Assault,Completed,1,1,0,0,Government/Public Building,Missing,0,November,Saturday,4:00pm-4:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192098606,2019-12-07,23C,Shoplifting,Completed,1,1,0,0,Department/Discount Store,Missing,0,December,Saturday,3:00pm-3:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192083216,2019-10-12,23D,Theft From Building,Completed,1,1,0,0,Residence/Home,Missing,0,October,Saturday,3:00pm-3:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192091432,2019-11-11,35A,Drug/Narcotic Violations,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,November,Monday,1:00pm-1:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192085267,2019-10-21,13B,Simple Assault,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,October,Monday,12:00n-12:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192104693,2019-12-30,13C,Intimidation,Completed,1,1,0,0,Shopping Mall,Missing,0,December,Monday,9:00am-9:59am,Suffolk County,Boston,Not Cleared,,2,2,1,0
+MA0130100,192085376,2019-10-21,13C,Intimidation,Completed,1,1,0,0,Residence/Home,Missing,0,October,Monday,4:00pm-4:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192097453,2019-12-03,23C,Shoplifting,Attempted,1,1,0,0,Department/Discount Store,Missing,0,December,Tuesday,3:00pm-3:59pm,Suffolk County,Boston,Not Cleared,,2,2,1,0
+MA0130100,202002532,2019-12-14,26E,Wire Fraud,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,December,Saturday,1:00am-1:59am,Suffolk County,Boston,Not Cleared,,2,1,2,0
+MA0130100,192102498,2019-12-21,13B,Simple Assault,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,December,Saturday,1:00am-1:59am,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192084238,2019-10-17,13C,Intimidation,Completed,1,1,0,0,Residence/Home,Missing,0,October,Thursday,9:00pm-9:59pm,Suffolk County,Boston,Cleared by Arrest,,2,2,1,1
+MA0130100,192100091,2019-12-09,23H,All Other Larceny,Completed,1,1,0,0,Residence/Home,Missing,0,December,Monday,2:00pm-2:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0
+MA0130100,192080570,2019-10-01,290,Destruction/Damage/Vandalism of Property,Completed,1,1,0,0,Highway/Road/Alley/Street/Sidewalk,Missing,0,October,Tuesday,11:00pm-11:59pm,Suffolk County,Boston,Not Cleared,,1,1,1,0

--- a/spec/lib/parser/nibrs_incident_reports_spec.rb
+++ b/spec/lib/parser/nibrs_incident_reports_spec.rb
@@ -1,0 +1,22 @@
+describe Parser::NibrsIncidentReports do
+    let(:file) { file_fixture("sample_boston_nibrs_foia.csv") }
+    let(:parser) { Parser::NibrsIncidentReports.new(file) }
+    let(:records) { parser.records }
+    let(:attribution) { parser.attribution }
+  
+    it "parses a record" do
+      record = records.first
+      expect(record[:incident_number]).to eql("192092484")
+    end
+  
+    it "parses all the records" do
+      expect(records.count).to eql(99)
+    end
+  
+    it "attributes" do
+      expect(attribution.filename).to eql("sample_boston_nibrs_foia.csv")
+      expect(attribution.category).to eql("nibrs_incident_reports")
+      expect(attribution.url).to eql(nil)
+    end
+  end
+  


### PR DESCRIPTION
addresses #18

Some notes:
* while this ingests all offense-level fields from the NIBRS data, it doesn't display all of them in the "NIBRS Offenses" table on the incident page - I wasn't sure what would be most useful and figured we can easily add more.
* for incidents that don't exist in the BPD's crime incident data, I don't try to construct a value for `occurred_on_date` from the date/time-related columns in the NIBRS data. This is probably doable, though - maybe something for a future PR!